### PR TITLE
Add coverage support and bump C++11 -> C++17

### DIFF
--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -24,7 +24,9 @@ enable_testing(){% endif %}{% if library or tests %}
 option(BUILD_SHARED_LIBS "Build dynamic libraries when on, else static" ON){% endif %}{% if tests %}
 option(TEST_WITH_VALGRIND "Run unit tests with valgrind (if CMAKE_CROSSCOMPILING_EMULATOR is defined, it will override this setting)" OFF){% endif %}
 
-add_compile_options(-Werror -Wall -Wpedantic -Wconversion)
+add_compile_options(-Werror -Wall -Wpedantic -Wconversion){% if tests %}
+set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} --coverage")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage"){% endif %}
 set(CMAKE_C_STANDARD 99){% if cxx or tests %}
 set(CMAKE_CXX_STANDARD 11){% endif %}{% if library %}
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined"){% endif %}{% if executable or tests %}

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -28,7 +28,7 @@ add_compile_options(-Werror -Wall -Wpedantic -Wconversion){% if tests %}
 set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} --coverage")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage"){% endif %}
 set(CMAKE_C_STANDARD 99){% if cxx or tests %}
-set(CMAKE_CXX_STANDARD 11){% endif %}{% if library %}
+set(CMAKE_CXX_STANDARD 17){% endif %}{% if library %}
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined"){% endif %}{% if executable or tests %}
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags"){% endif %}
 


### PR DESCRIPTION
Played around with gcov (code coverage) and CLion this weekend. Thought I'd add the support to jumpstart.

Also noticed that the C++ standard was still set to C++11, so I go that updated to the latest version supported by GCC 7 (GCC 7 is what we now use on s5t platform)